### PR TITLE
Update install instructions for iOS

### DIFF
--- a/source/includes/_adding_smooch_ios.md
+++ b/source/includes/_adding_smooch_ios.md
@@ -68,10 +68,10 @@ If you're writing an app using Swift, then you'll need to import this header int
 
 ## Add Required Keys in your app's Info.plist
 
-The Smooch SDK provides an option to send an image from its user interface. In order to support these features, we need to request the user access to the device's camera and the user's photo library. Include a description explaining the purpose of these features in your app's Info.plist. These descriptions will be displayed as part of the alert when the system prompts the user to allow access. The keys are:
+The Smooch SDK allows user to send images to you. To support this feature, you must provide a description in your app's Info.plist to explain why access to the camera and photo library is required.
 
-* NSCameraUsageDescription: describes the reason your app access the device's camera. More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
-* NSPhotoLibraryUsageDescription: describes the reason your app accesses the user’s photo library. More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW17)
+* NSCameraUsageDescription: describes the reason your app access the camera. More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
+* NSPhotoLibraryUsageDescription: describes the reason your app accesses the photo library. More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW17)
 
 <aside class="notice">
 Starting from iOS 10, these values are required. If they are not present in your app's Info.plist, the option to send an image will not be displayed.

--- a/source/includes/_adding_smooch_ios.md
+++ b/source/includes/_adding_smooch_ios.md
@@ -68,7 +68,7 @@ If you're writing an app using Swift, then you'll need to import this header int
 
 ## Add Required Keys in your app's Info.plist
 
-The Smooch SDK allows users to send images to you. To support this feature, you must provide a description in your app's Info.plist to explain why access to the camera and photo library is required.
+The Smooch SDK allows users to send images to you. To support this feature, you must provide a description in your app's Info.plist to explain why access to the camera and photo library is required. These descriptions will be displayed as part of the alert when the system prompts the user to allow access. The keys are:
 
 * NSCameraUsageDescription: describes the reason your app access the camera. More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
 * NSPhotoLibraryUsageDescription: describes the reason your app accesses the photo library. More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW17)

--- a/source/includes/_adding_smooch_ios.md
+++ b/source/includes/_adding_smooch_ios.md
@@ -66,6 +66,17 @@ Import the Smooch file into the your app delegate's .m file and any other places
 If you're writing an app using Swift, then you'll need to import this header into a "bridging header". More info on this is available from [Apple](https://developer.apple.com/library/ios/documentation/swift/conceptual/buildingcocoaapps/MixandMatch.html)
 </aside>
 
+## Add Required Keys in your app's Info.plist
+
+The Smooch SDK provides an option to send an image from its user interface. In order to support these features, we need to request the user access to the device's camera and the user's photo library. Include a description explaining the purpose of these features in your app's Info.plist. These descriptions will be displayed as part of the alert when the system prompts the user to allow access. The keys are:
+
+* NSCameraUsageDescription: describes the reason your app access the device's camera. More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
+* NSPhotoLibraryUsageDescription: describes the reason your app accesses the user’s photo library. More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW17)
+
+<aside class="notice">
+Starting from iOS 10, these values are required. If they are not present in your app's Info.plist, the option to send an image will not be displayed.
+</aside>
+
 ## Initialize Smooch in your app
 
 

--- a/source/includes/_adding_smooch_ios.md
+++ b/source/includes/_adding_smooch_ios.md
@@ -70,8 +70,8 @@ If you're writing an app using Swift, then you'll need to import this header int
 
 The Smooch SDK allows users to send images to you. To support this feature, you must provide a description in your app's Info.plist to explain why access to the camera and photo library is required. These descriptions will be displayed as part of the alert when the system prompts the user to allow access. The keys are:
 
-* NSCameraUsageDescription: describes the reason your app access the camera. More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
-* NSPhotoLibraryUsageDescription: describes the reason your app accesses the photo library. More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW17)
+* NSCameraUsageDescription: describes the reason your app access the camera (ex: `Camera permission is required to send images to ${PRODUCT_NAME}`). More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
+* NSPhotoLibraryUsageDescription: describes the reason your app accesses the photo library (ex: `Photo library permission is required to send images to ${PRODUCT_NAME}`). More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW17)
 
 <aside class="notice">
 Starting from iOS 10, these values are required. If they are not present in your app's Info.plist, the option to send an image will not be displayed.

--- a/source/includes/_adding_smooch_ios.md
+++ b/source/includes/_adding_smooch_ios.md
@@ -68,7 +68,7 @@ If you're writing an app using Swift, then you'll need to import this header int
 
 ## Add Required Keys in your app's Info.plist
 
-The Smooch SDK allows user to send images to you. To support this feature, you must provide a description in your app's Info.plist to explain why access to the camera and photo library is required.
+The Smooch SDK allows users to send images to you. To support this feature, you must provide a description in your app's Info.plist to explain why access to the camera and photo library is required.
 
 * NSCameraUsageDescription: describes the reason your app access the camera. More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24)
 * NSPhotoLibraryUsageDescription: describes the reason your app accesses the photo library. More information available [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW17)


### PR DESCRIPTION
Starting from iOS 10, the keys NSPhotoLibraryUsageDescription and NSCameraUsageDescription are required in order to request the user access to the device's camera and the user's photo library

@jpjoyal @mspensieri 